### PR TITLE
fix warnings in Scala 2.13. use string interpolation

### DIFF
--- a/src/main/scala/jp/co/dwango/s99/P67.scala
+++ b/src/main/scala/jp/co/dwango/s99/P67.scala
@@ -73,7 +73,7 @@ object P67 {
       val c0 = input.charAt(0)
       if (c0 >= 'A' && c0 <= 'Z' || c0 >= 'a' && c0 <= 'z')
         Success(c0, input.substring(1))
-      else Failure(c0 + " is not a letter")
+      else Failure(s"$c0 is not a letter")
     }
   })
   def char(c: Char): Parser[Char] =
@@ -83,7 +83,7 @@ object P67 {
         val c0 = input.charAt(0)
         if (c0 == c)
           Success(c0, input.substring(1))
-        else Failure(c0 + " is not " + c)
+        else Failure(s"$c0 is not $c")
       }
     })
   lazy val node

--- a/src/main/scala/jp/co/dwango/s99/P96.scala
+++ b/src/main/scala/jp/co/dwango/s99/P96.scala
@@ -42,18 +42,18 @@ object P96 {
     else if (input.charAt(0) >= 'A' && input.charAt(0) <= 'Z' || input
                .charAt(0) >= 'a' && input.charAt(0) <= 'z')
       Success(input.substring(1))
-    else Failure(input.charAt(0) + " is not a letter")
+    else Failure(s"${input.charAt(0)} is not a letter")
   })
   lazy val digit: Parser = new Parser(input => {
     if (input.length == 0) Failure("no rest input")
     else if (input.charAt(0) >= '0' && input.charAt(0) <= '9')
       Success(input.substring(1))
-    else Failure(input.charAt(0) + " is not a digit")
+    else Failure(s"${input.charAt(0)} is not a digit")
   })
   lazy val UNDERSCORE: Parser = new Parser(input => {
     if (input.length == 0) Failure("no rest input")
     else if (input.charAt(0) == '_') Success(input.substring(1))
-    else Failure(input.charAt(0) + " is not a '_'")
+    else Failure(s"${input.charAt(0)} is not a '_'")
   })
   lazy val identifierLoop
     : Parser = UNDERSCORE.? ~ (letter | digit) ~ identifierLoop.?


### PR DESCRIPTION
```
[warn] /home/travis/build/xuwei-k/S99/src/main/scala/jp/co/dwango/s99/P67.scala:76:23: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
[warn]       else Failure(c0 + " is not a letter")
[warn]                       ^
[warn] /home/travis/build/xuwei-k/S99/src/main/scala/jp/co/dwango/s99/P67.scala:86:25: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
[warn]         else Failure(c0 + " is not " + c)
[warn]                         ^
[warn] /home/travis/build/xuwei-k/S99/src/main/scala/jp/co/dwango/s99/P96.scala:45:34: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
[warn]     else Failure(input.charAt(0) + " is not a letter")
[warn]                                  ^
[warn] /home/travis/build/xuwei-k/S99/src/main/scala/jp/co/dwango/s99/P96.scala:51:34: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
[warn]     else Failure(input.charAt(0) + " is not a digit")
[warn]                                  ^
[warn] /home/travis/build/xuwei-k/S99/src/main/scala/jp/co/dwango/s99/P96.scala:56:34: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
[warn]     else Failure(input.charAt(0) + " is not a '_'")
[warn]                                  ^
```